### PR TITLE
Update README.md with correct installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires PHP 7.0+ and Symfony 4.0+.
 Install with Composer:
 
 ```
-composer install avensome/commonmark-bundle
+composer require avensome/commonmark-bundle
 ```
 
 Then add `Avensome\CommonMarkBundle\AvensomeCommonMarkBundle` to `config/bundles.php`:


### PR DESCRIPTION
You can't `composer install package`.
It should be `composer require package`.

I mix this up all the time switching between yarn and composer, too..